### PR TITLE
Introduce CSS variables for font size customization

### DIFF
--- a/dist/ha-public-transport-connection-card.js
+++ b/dist/ha-public-transport-connection-card.js
@@ -285,6 +285,35 @@ import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.
                 font-size: var(--ptcd-first-platform-font-size);
             }
 
+            .ptcd-first-departure-compact {
+                justify-content: space-between;
+                gap: var(--public-transport-card-inner-padding);
+            }
+
+            .ptcd-first-departure-compact .ptcd-time-departure,
+            .ptcd-first-departure-compact .ptcd-time-departure-offset,
+            .ptcd-first-departure-compact .ptcd-train,
+            .ptcd-first-departure-compact .ptcd-platform {
+                flex: 1;
+            }
+
+            .ptcd-first-departure-compact .ptcd-direction {
+                flex: 2;
+                white-space: nowrap;
+            }
+
+            .ptcd-first-departure-compact .ptcd-next-stations {
+                flex: 3;
+                flex-shrink: 2;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            .ptcd-first-departure-compact .ptcd-platform:last-child {
+                text-align: right;
+            }
+
             .ptcd-next-departure {
                 font-size: var(--ptcd-next-departure-font-size);
                 opacity: 0.9;
@@ -319,9 +348,13 @@ import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.
                 <div class="no-departures" @click="${ev=>this.handleAction("tap")}">
                     No departures found.
                 </div>
-            `}const nextDepartures=[...departures];const firstDeparture=layoutConfig.firstDepartureLayout?nextDepartures.shift():undefined;return html`
+            `}const nextDepartures=[...departures];const firstDeparture=layoutConfig.firstDepartureLayout?nextDepartures.shift():undefined;const firstDepartureCompact=firstDeparture&&firstDeparture.nextStations.length===0;return html`
             <div class="ptcd-main ptcd-layout-${this.config.layout}" @click="${ev=>this.handleAction("tap")}">
-                ${layoutConfig.firstDepartureLayout&&firstDeparture?html`
+                ${layoutConfig.firstDepartureLayout&&firstDeparture?firstDepartureCompact?html`
+                    <div class="ptcd-row ptcd-first-departure ptcd-first-departure-compact ${firstDeparture.isCancelled?"ptcd-is-cancelled":""}">
+                        ${layoutConfig.columns.map(column=>this._renderColumn(firstDeparture,column))}
+                    </div>
+                `:html`
                     <div class="ptcd-row ptcd-first-departure ${firstDeparture.isCancelled?"ptcd-is-cancelled":""}">
                         ${layoutConfig.firstDepartureLayout.map(row=>html`
                             <div class="ptcd-first-departure-section ${row.length===0?"ptcd-spacer":""}">

--- a/dist/ha-public-transport-connection-card.js
+++ b/dist/ha-public-transport-connection-card.js
@@ -214,6 +214,7 @@ import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.
                  * --ptcd-next-departure-font-size   Alle Folgezeilen
                  */
                 --ptcd-first-departure-font-size: 1em;
+                --ptcd-first-departure-second-font-size: 0.85em;
                 --ptcd-first-platform-font-size: 1.2em;
                 --ptcd-next-departure-font-size: 0.85em;
             }
@@ -271,6 +272,10 @@ import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.
 
             .ptcd-first-departure > .ptcd-first-departure-section > :first-child {
                 font-size: var(--ptcd-first-departure-font-size);
+            }
+
+            .ptcd-first-departure > .ptcd-first-departure-section > :last-child:not(:first-child) {
+                font-size: var(--ptcd-first-departure-second-font-size);
             }
 
             .ptcd-first-departure > .ptcd-first-departure-section > .ptcd-platform:first-child:last-child {

--- a/dist/ha-public-transport-connection-card.js
+++ b/dist/ha-public-transport-connection-card.js
@@ -8,6 +8,10 @@ import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.
 
                 /* Schriftgrößen-Variablen */
                 --ptc-title-font-size: 16px;
+
+                /* Titel-Abstände */
+                --ptc-title-margin-top: calc(var(--public-transport-card-inner-padding) * 2);
+                --ptc-title-margin-bottom: calc(var(--public-transport-card-inner-padding) / 2);
             }
 
             ha-card {
@@ -26,7 +30,7 @@ import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.
                 font-family: var(--ha-card-header-font-family, inherit);
                 font-size: var(--ptc-title-font-size);
                 font-weight: 400;
-                margin: calc(var(--public-transport-card-inner-padding) * 2) calc(var(--public-transport-card-inner-padding) * 1.5) calc(var(--public-transport-card-inner-padding) / 2);
+                margin: var(--ptc-title-margin-top) calc(var(--public-transport-card-inner-padding) * 1.5) var(--ptc-title-margin-bottom);
             }
 
             /* Themes */

--- a/dist/ha-public-transport-connection-card.js
+++ b/dist/ha-public-transport-connection-card.js
@@ -288,6 +288,7 @@ import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.
             .ptcd-first-departure-compact {
                 justify-content: space-between;
                 gap: var(--public-transport-card-inner-padding);
+                font-size: var(--ptcd-first-departure-font-size);
             }
 
             .ptcd-first-departure-compact .ptcd-time-departure,

--- a/dist/ha-public-transport-connection-card.js
+++ b/dist/ha-public-transport-connection-card.js
@@ -29,7 +29,7 @@ import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.
             h1 {
                 font-family: var(--ha-card-header-font-family, inherit);
                 font-size: var(--ptc-title-font-size);
-                font-weight: 400;
+                font-weight: var(--ptc-title-font-weight, 700);
                 margin: var(--ptc-title-margin-top) calc(var(--public-transport-card-inner-padding) * 1.5) var(--ptc-title-margin-bottom);
             }
 

--- a/dist/ha-public-transport-connection-card.js
+++ b/dist/ha-public-transport-connection-card.js
@@ -1,10 +1,13 @@
-import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.js?module";function ptcDelayToMinutes(delay){if(typeof delay==="number"){return delay}if(typeof delay==="string"&&delay.includes(":")){const delayParts=delay.split(":");const hours=parseInt(delayParts[0])||0;const minutes=parseInt(delayParts[1])||0;return hours*60+minutes}return parseInt(delay)||0}function ptcTimeToStr(time){const parse=Date.parse(time);return parse?new Date(parse).toLocaleTimeString([],{timeStyle:"short"}):time}function ptcTimeOffset(time,delay){const[targetHours,targetMinutes]=time.split(":").map(Number);const now=new Date;const currentHours=now.getHours();const currentMinutes=now.getMinutes();const currentTotalMinutes=currentHours*60+currentMinutes;const targetTotalMinutes=targetHours*60+targetMinutes;let offset=targetTotalMinutes-currentTotalMinutes;if(offset<-3*60){offset+=24*60}return offset+delay}function ptcParseBool(value){if(typeof value==="boolean"){return value}if(typeof value==="number"){return value!==0}if(typeof value==="string"){return value.toLowerCase()==="true"}return false}class PublicTransprtAbstractCard extends LitElement{static AVAILABLE_THEMES=["deutsche-bahn","homeassistant"];static getConfigForm(){return{schema:[{name:"entity",required:true,selector:{entity:{domain:"sensor"}}},{name:"title",selector:{text:{}}},{name:"theme",selector:{select:{options:this.AVAILABLE_THEMES,custom_value:true}}}]}}static detectDefaultConfig(defaultConfigs,entityIds,hass){const configs=Array.isArray(defaultConfigs)?defaultConfigs:Object.values(defaultConfigs);for(const defaultConfig of configs){const entityId=entityIds.find((entityId=>{const entity=hass.states[entityId];let entityChecked=false;if(defaultConfig.entityTypes){const entityType=entityId.split(".")[0];if(!defaultConfig.entityTypes.includes(entityType)){return false}entityChecked=true}if(defaultConfig.entityAttributes){let attributesExist=true;for(const attribute of defaultConfig.entityAttributes){if(entity.attributes[attribute]===undefined){attributesExist=false;break}}if(!attributesExist){return false}entityChecked=true}if(defaultConfig.isEntitySupported){return defaultConfig.isEntitySupported(entity)}if(entityChecked){return true}throw new Error("Implementation error: The default configuration object must at least provide one method for entity detection.")}));if(entityId){return defaultConfig.getConfig(hass.states[entityId])}}return undefined}static getStubConfig(hass,unusedEntities,allEntities){return{title:"",entity:"",theme:"deutsche-bahn"}}static get properties(){return{hass:{},config:{}}}static get styles(){return css`
+import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.js?module";function ptcDelayToMinutes(delay){if(typeof delay==="number"){return delay}if(typeof delay==="string"&&delay.includes(":")){const delayParts=delay.split(":");const hours=parseInt(delayParts[0])||0;const minutes=parseInt(delayParts[1])||0;return hours*60+minutes}return parseInt(delay)||0}function ptcTimeToStr(time){const parse=Date.parse(time);return parse?new Date(parse).toLocaleTimeString([],{timeStyle:"short"}):time}function ptcTimeOffset(time,delay){const[targetHours,targetMinutes]=time.split(":").map(Number);const now=new Date;const currentHours=now.getHours();const currentMinutes=now.getMinutes();const currentTotalMinutes=currentHours*60+currentMinutes;const targetTotalMinutes=targetHours*60+targetMinutes;let offset=targetTotalMinutes-currentTotalMinutes;if(offset<-3*60){offset+=24*60}return offset+delay}function ptcParseBool(value){if(typeof value==="boolean"){return value}if(typeof value==="number"){return value!==0}if(typeof value==="string"){return value.toLowerCase()==="true"}return false}class PublicTransprtAbstractCard extends LitElement{static AVAILABLE_THEMES=["deutsche-bahn","homeassistant"];static getConfigForm(){return{schema:[{name:"entity",required:true,selector:{entity:{domain:"sensor"}}},{name:"title",selector:{text:{}}},{name:"theme",selector:{select:{options:this.AVAILABLE_THEMES,custom_value:true}}}]}}static detectDefaultConfig(defaultConfigs,entityIds,hass){const configs=Array.isArray(defaultConfigs)?defaultConfigs:Object.values(defaultConfigs);for(const defaultConfig of configs){const entityId=entityIds.find(entityId=>{const entity=hass.states[entityId];let entityChecked=false;if(defaultConfig.entityTypes){const entityType=entityId.split(".")[0];if(!defaultConfig.entityTypes.includes(entityType)){return false}entityChecked=true}if(defaultConfig.entityAttributes){let attributesExist=true;for(const attribute of defaultConfig.entityAttributes){if(entity.attributes[attribute]===undefined){attributesExist=false;break}}if(!attributesExist){return false}entityChecked=true}if(defaultConfig.isEntitySupported){return defaultConfig.isEntitySupported(entity)}if(entityChecked){return true}throw new Error("Implementation error: The default configuration object must at least provide one method for entity detection.")});if(entityId){return defaultConfig.getConfig(hass.states[entityId])}}return undefined}static getStubConfig(hass,unusedEntities,allEntities){return{title:"",entity:"",theme:"deutsche-bahn"}}static get properties(){return{hass:{},config:{}}}static get styles(){return css`
             :host {
                 --public-transport-card-background-color: #EC0016;
                 --public-transport-card-foreground-color: #FFFFFF;
                 --public-transport-card-size: 10px;
 
                 --public-transport-card-inner-padding: var(--public-transport-card-size);
+
+                /* Schriftgrößen-Variablen */
+                --ptc-title-font-size: 16px;
             }
 
             ha-card {
@@ -21,7 +24,7 @@ import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.
 
             h1 {
                 font-family: var(--ha-card-header-font-family, inherit);
-                font-size: var(--ha-card-header-font-size, 24px);
+                font-size: var(--ptc-title-font-size);
                 font-weight: 400;
                 margin: calc(var(--public-transport-card-inner-padding) * 2) calc(var(--public-transport-card-inner-padding) * 1.5) calc(var(--public-transport-card-inner-padding) / 2);
             }
@@ -85,7 +88,7 @@ import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.
                         ${currentConnection.arrival.delay>0?html`+ ${currentConnection.arrival.delay}`:""}
                     </div>
                 </div>
-                ${connections.map((connection=>html`
+                ${connections.map(connection=>html`
                     <div class="ptc-row ptc-connection ptc-next-connection">
                         <div class="ptc-time-departure">
                             ${connection.departure.time}
@@ -97,7 +100,7 @@ import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.
                             ${connection.arrival.delay>0?html`+ ${connection.arrival.delay}`:""}
                         </div>
                     </div>
-                `))}
+                `)}
             </div>
         `}modifyConfig(config){const mergedConfig={tap_action:{action:"more-info"},...config};return super.modifyConfig(mergedConfig)}getCardSize(){return 2}getLayoutOptions(){return{grid_rows:2,grid_columns:4,grid_min_rows:2,grid_min_columns:2}}static get styles(){return css`
             ${super.styles}
@@ -201,6 +204,20 @@ import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.
         `}}class PublicTransportDepartureCard extends PublicTransprtAbstractCard{static FIRST_DEPARTURE_LAYOUT=[["time","train"],["direction","next_stations"],[],["platform"]];static LAYOUT_PRESETS={station_departures:{firstDepartureLayout:this.FIRST_DEPARTURE_LAYOUT,columns:["time","train","next_stations","direction","platform"],layoutOptions:{grid_rows:3,grid_columns:4,grid_min_rows:2,grid_min_columns:3}},platform_departures:{firstDepartureLayout:[["train"],["direction"],[],["offset"]],columns:["train","direction","offset"],layoutOptions:{grid_rows:2,grid_columns:4,grid_min_rows:2,grid_min_columns:2}},fixed_destination:{firstDepartureLayout:this.FIRST_DEPARTURE_LAYOUT,columns:["time","train","next_stations","platform"],layoutOptions:{grid_rows:3,grid_columns:4,grid_min_rows:2,grid_min_columns:2}}};static getConfigForm(){return{schema:[...super.getConfigForm().schema,{name:"layout",required:true,selector:{select:{options:Object.keys(this.LAYOUT_PRESETS),custom_value:false}}},{name:"departures_attribute",required:true,selector:{attribute:{entity_id:""}},context:{filter_entity:"entity"}},{name:"departure_properties",type:"grid",schema:[{name:"time",required:true,selector:{text:{}}},{name:"delay",selector:{text:{}}},{name:"cancelled",selector:{text:{}}},{name:"train",selector:{text:{}}},{name:"direction",required:true,selector:{text:{}}},{name:"platform",selector:{text:{}}},{name:"next_stations",selector:{text:{}}}]},{name:"destination_filter",selector:{text:{}}},{name:"displayed_departures",selector:{number:{min:1}}}]}}static getStubConfig(hass,unusedEntities,allEntities){const defaultConfigs={db_infoscreen:{entityTypes:["sensor"],entityAttributes:["next_departures"],getConfig:entity=>({entity:entity.entity_id,station:entity.attributes.station,departures_attribute:"next_departures",departure_properties:{time:"scheduledDeparture",delay:"delayDeparture",cancelled:"isCancelled",train:"train",direction:"destination",platform:"platform",next_stations:"via"}})}};const defaultConfig=super.detectDefaultConfig(defaultConfigs,[...unusedEntities,...allEntities],hass)||{};return{...super.getStubConfig(hass,unusedEntities,allEntities),layout:Object.keys(this.LAYOUT_PRESETS)[0],departures_attribute:"",departure_properties:{time:"",delay:"",cancelled:"",train:"",direction:"",platform:"",next_stations:""},destination_filter:"",displayed_departures:5,...defaultConfig}}static get styles(){return css`
             ${super.styles}
 
+            :host {
+                /*
+                 * Schriftgrößen-Variablen -- alle hier anpassbar:
+                 *
+                 * --ptc-title-font-size            Kartentitel (geerbt von abstract-card)
+                 * --ptcd-first-departure-font-size  Erste Abfahrt: Zeit + Zug (große Zeile)
+                 * --ptcd-first-platform-font-size   Erste Abfahrt: Gleisnummer rechts
+                 * --ptcd-next-departure-font-size   Alle Folgezeilen
+                 */
+                --ptcd-first-departure-font-size: 1em;
+                --ptcd-first-platform-font-size: 1.2em;
+                --ptcd-next-departure-font-size: 0.85em;
+            }
+
             .ptd-main {
                 display: flex;
                 width: 100%;
@@ -253,17 +270,18 @@ import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.
             }
 
             .ptcd-first-departure > .ptcd-first-departure-section > :first-child {
-                font-size: 1.3em;
+                font-size: var(--ptcd-first-departure-font-size);
             }
+
             .ptcd-first-departure > .ptcd-first-departure-section > .ptcd-platform:first-child:last-child {
                 display: flex;
                 height: 100%;
                 align-items: center;
-                font-size: 2em;
+                font-size: var(--ptcd-first-platform-font-size);
             }
 
             .ptcd-next-departure {
-                font-size: 0.85em;
+                font-size: var(--ptcd-next-departure-font-size);
                 opacity: 0.9;
             }
 
@@ -300,20 +318,20 @@ import{LitElement,html,css}from"https://unpkg.com/lit-element@2.0.1/lit-element.
             <div class="ptcd-main ptcd-layout-${this.config.layout}" @click="${ev=>this.handleAction("tap")}">
                 ${layoutConfig.firstDepartureLayout&&firstDeparture?html`
                     <div class="ptcd-row ptcd-first-departure ${firstDeparture.isCancelled?"ptcd-is-cancelled":""}">
-                        ${layoutConfig.firstDepartureLayout.map((row=>html`
+                        ${layoutConfig.firstDepartureLayout.map(row=>html`
                             <div class="ptcd-first-departure-section ${row.length===0?"ptcd-spacer":""}">
-                                ${row.map((column=>this._renderColumn(firstDeparture,column)))}
+                                ${row.map(column=>this._renderColumn(firstDeparture,column))}
                             </div>
-                        `))}
+                        `)}
                     </div>
                 `:""}
-                ${nextDepartures.map((departure=>html`
+                ${nextDepartures.map(departure=>html`
                     <div class="ptcd-row ptcd-next-departure ${departure.isCancelled?"ptcd-is-cancelled":""}">
-                        ${layoutConfig.columns.map((column=>this._renderColumn(departure,column)))}
+                        ${layoutConfig.columns.map(column=>this._renderColumn(departure,column))}
                     </div>
-                `))}
+                `)}
             </div>
-        `}modifyConfig(config){const mergedConfig={tap_action:{action:"more-info"},...config};if(!mergedConfig.layout||mergedConfig.layout===""){mergedConfig.layout=Object.keys(this.constructor.LAYOUT_PRESETS)[0]}if(mergedConfig.destination_filter){if(typeof mergedConfig.destination_filter==="string"){mergedConfig.destination_filter=mergedConfig.destination_filter.split(";")}if(Array.isArray(mergedConfig.destination_filter)){mergedConfig.destination_filter=mergedConfig.destination_filter.map((filter=>filter.trim())).filter((filter=>filter!=="")).map((filter=>filter.toUpperCase()))}}return super.modifyConfig(mergedConfig)}checkConfig(config){super.checkConfig(config);if(!Object.keys(this.constructor.LAYOUT_PRESETS).includes(config.layout)){throw new Error("You must define a valid layout. Available layouts: "+Object.keys(this.constructor.LAYOUT_PRESETS).join(", "))}if(!config.departures_attribute||config.departures_attribute===""){throw new Error("You must define which attribute of the sensor holds the departures as array.")}if(!config.departure_properties){throw new Error("You must define the departure_properties.")}if(!config.departure_properties.time){throw new Error("You must define the time property for the departure entries.")}if(!config.departure_properties.direction){throw new Error("You must define the direction property for the departure entries.")}if(!config.displayed_departures||config.displayed_departures<1){throw new Error("displayed_connections must be set to 1 or higher")}if(config.destination_filter&&!Array.isArray(config.destination_filter)){throw new Error("destination_filter must be a string or an array of strings.")}}getCardSize(){return this.constructor.LAYOUT_PRESETS[this.config.layout||""].cardSize||2}getLayoutOptions(){return this.constructor.LAYOUT_PRESETS[this.config.layout||""].layoutOptions||{grid_rows:2,grid_columns:4,grid_min_rows:2,grid_min_columns:2}}_getDepartures(){const stateObj=this.hass.states[this.config.entity];const stateDepartures=stateObj.attributes[this.config.departures_attribute]||[];const departures=[];for(let i=0;i<stateDepartures.length&&departures.length<this.config.displayed_departures;i++){const stateDeparture=stateDepartures[i];const departure={time:ptcTimeToStr(stateDeparture[this.config.departure_properties.time]||""),delay:0,isCancelled:false,train:"",direction:stateDeparture[this.config.departure_properties.direction]||"",platform:"",nextStations:[]};if(this.config.departure_properties.delay){departure.delay=ptcDelayToMinutes(stateDeparture[this.config.departure_properties.delay]||0)}if(this.config.departure_properties.cancelled){departure.isCancelled=ptcParseBool(stateDeparture[this.config.departure_properties.cancelled]||false)}if(this.config.departure_properties.train){departure.train=stateDeparture[this.config.departure_properties.train]||""}if(this.config.departure_properties.platform){departure.platform=stateDeparture[this.config.departure_properties.platform]||""}if(this.config.departure_properties.next_stations){departure.nextStations=stateDeparture[this.config.departure_properties.next_stations]||[]}if(Array.isArray(this.config.destination_filter)&&this.config.destination_filter.length>0){const filters=this.config.destination_filter;let hasMatch=false;filters.forEach((filter=>{if(departure.direction.toUpperCase().includes(filter)||departure.nextStations.join("; ").toUpperCase().includes(filter)){hasMatch=true}}));if(!hasMatch){continue}}departures.push(departure)}return departures}_renderColumn(departure,columnType){switch(columnType){case"time":return html`
+        `}modifyConfig(config){const mergedConfig={tap_action:{action:"more-info"},...config};if(!mergedConfig.layout||mergedConfig.layout===""){mergedConfig.layout=Object.keys(this.constructor.LAYOUT_PRESETS)[0]}if(mergedConfig.destination_filter){if(typeof mergedConfig.destination_filter==="string"){mergedConfig.destination_filter=mergedConfig.destination_filter.split(";")}if(Array.isArray(mergedConfig.destination_filter)){mergedConfig.destination_filter=mergedConfig.destination_filter.map(filter=>filter.trim()).filter(filter=>filter!=="").map(filter=>filter.toUpperCase())}}return super.modifyConfig(mergedConfig)}checkConfig(config){super.checkConfig(config);if(!Object.keys(this.constructor.LAYOUT_PRESETS).includes(config.layout)){throw new Error("You must define a valid layout. Available layouts: "+Object.keys(this.constructor.LAYOUT_PRESETS).join(", "))}if(!config.departures_attribute||config.departures_attribute===""){throw new Error("You must define which attribute of the sensor holds the departures as array.")}if(!config.departure_properties){throw new Error("You must define the departure_properties.")}if(!config.departure_properties.time){throw new Error("You must define the time property for the departure entries.")}if(!config.departure_properties.direction){throw new Error("You must define the direction property for the departure entries.")}if(!config.displayed_departures||config.displayed_departures<1){throw new Error("displayed_connections must be set to 1 or higher")}if(config.destination_filter&&!Array.isArray(config.destination_filter)){throw new Error("destination_filter must be a string or an array of strings.")}}getCardSize(){return this.constructor.LAYOUT_PRESETS[this.config.layout||""].cardSize||2}getLayoutOptions(){return this.constructor.LAYOUT_PRESETS[this.config.layout||""].layoutOptions||{grid_rows:2,grid_columns:4,grid_min_rows:2,grid_min_columns:2}}_getDepartures(){const stateObj=this.hass.states[this.config.entity];const stateDepartures=stateObj.attributes[this.config.departures_attribute]||[];const departures=[];for(let i=0;i<stateDepartures.length&&departures.length<this.config.displayed_departures;i++){const stateDeparture=stateDepartures[i];const departure={time:ptcTimeToStr(stateDeparture[this.config.departure_properties.time]||""),delay:0,isCancelled:false,train:"",direction:stateDeparture[this.config.departure_properties.direction]||"",platform:"",nextStations:[]};if(this.config.departure_properties.delay){departure.delay=ptcDelayToMinutes(stateDeparture[this.config.departure_properties.delay]||0)}if(this.config.departure_properties.cancelled){departure.isCancelled=ptcParseBool(stateDeparture[this.config.departure_properties.cancelled]||false)}if(this.config.departure_properties.train){departure.train=stateDeparture[this.config.departure_properties.train]||""}if(this.config.departure_properties.platform){departure.platform=stateDeparture[this.config.departure_properties.platform]||""}if(this.config.departure_properties.next_stations){departure.nextStations=stateDeparture[this.config.departure_properties.next_stations]||[]}if(Array.isArray(this.config.destination_filter)&&this.config.destination_filter.length>0){const filters=this.config.destination_filter;let hasMatch=false;filters.forEach(filter=>{if(departure.direction.toUpperCase().includes(filter)||departure.nextStations.join("; ").toUpperCase().includes(filter)){hasMatch=true}});if(!hasMatch){continue}}departures.push(departure)}return departures}_renderColumn(departure,columnType){switch(columnType){case"time":return html`
                     <div class="ptcd-time-departure">
                         ${departure.time}
                         ${departure.delay>0?html`+ ${departure.delay}`:""}

--- a/src/cards/abstract-card.js
+++ b/src/cards/abstract-card.js
@@ -189,7 +189,7 @@ class PublicTransprtAbstractCard extends LitElement {
             h1 {
                 font-family: var(--ha-card-header-font-family, inherit);
                 font-size: var(--ptc-title-font-size);
-                font-weight: 400;
+                font-weight: var(--ptc-title-font-weight, 700);
                 margin: var(--ptc-title-margin-top) calc(var(--public-transport-card-inner-padding) * 1.5) var(--ptc-title-margin-bottom);
             }
 

--- a/src/cards/abstract-card.js
+++ b/src/cards/abstract-card.js
@@ -165,6 +165,9 @@ class PublicTransprtAbstractCard extends LitElement {
                 --public-transport-card-size: 10px;
 
                 --public-transport-card-inner-padding: var(--public-transport-card-size);
+
+                /* Schriftgrößen-Variablen */
+                --ptc-title-font-size: 16px;
             }
 
             ha-card {
@@ -181,7 +184,7 @@ class PublicTransprtAbstractCard extends LitElement {
 
             h1 {
                 font-family: var(--ha-card-header-font-family, inherit);
-                font-size: var(--ha-card-header-font-size, 24px);
+                font-size: var(--ptc-title-font-size);
                 font-weight: 400;
                 margin: calc(var(--public-transport-card-inner-padding) * 2) calc(var(--public-transport-card-inner-padding) * 1.5) calc(var(--public-transport-card-inner-padding) / 2);
             }

--- a/src/cards/abstract-card.js
+++ b/src/cards/abstract-card.js
@@ -168,6 +168,10 @@ class PublicTransprtAbstractCard extends LitElement {
 
                 /* Schriftgrößen-Variablen */
                 --ptc-title-font-size: 16px;
+
+                /* Titel-Abstände */
+                --ptc-title-margin-top: calc(var(--public-transport-card-inner-padding) * 2);
+                --ptc-title-margin-bottom: calc(var(--public-transport-card-inner-padding) / 2);
             }
 
             ha-card {
@@ -186,7 +190,7 @@ class PublicTransprtAbstractCard extends LitElement {
                 font-family: var(--ha-card-header-font-family, inherit);
                 font-size: var(--ptc-title-font-size);
                 font-weight: 400;
-                margin: calc(var(--public-transport-card-inner-padding) * 2) calc(var(--public-transport-card-inner-padding) * 1.5) calc(var(--public-transport-card-inner-padding) / 2);
+                margin: var(--ptc-title-margin-top) calc(var(--public-transport-card-inner-padding) * 1.5) var(--ptc-title-margin-bottom);
             }
 
             /* Themes */

--- a/src/cards/departure-card.js
+++ b/src/cards/departure-card.js
@@ -195,6 +195,20 @@ class PublicTransportDepartureCard extends PublicTransprtAbstractCard {
         return css`
             ${super.styles}
 
+            :host {
+                /*
+                 * Schriftgrößen-Variablen -- alle hier anpassbar:
+                 *
+                 * --ptc-title-font-size            Kartentitel (geerbt von abstract-card)
+                 * --ptcd-first-departure-font-size  Erste Abfahrt: Zeit + Zug (große Zeile)
+                 * --ptcd-first-platform-font-size   Erste Abfahrt: Gleisnummer rechts
+                 * --ptcd-next-departure-font-size   Alle Folgezeilen
+                 */
+                --ptcd-first-departure-font-size: 1em;
+                --ptcd-first-platform-font-size: 1.2em;
+                --ptcd-next-departure-font-size: 0.85em;
+            }
+
             .ptd-main {
                 display: flex;
                 width: 100%;
@@ -247,17 +261,18 @@ class PublicTransportDepartureCard extends PublicTransprtAbstractCard {
             }
 
             .ptcd-first-departure > .ptcd-first-departure-section > :first-child {
-                font-size: 1.3em;
+                font-size: var(--ptcd-first-departure-font-size);
             }
+
             .ptcd-first-departure > .ptcd-first-departure-section > .ptcd-platform:first-child:last-child {
                 display: flex;
                 height: 100%;
                 align-items: center;
-                font-size: 2em;
+                font-size: var(--ptcd-first-platform-font-size);
             }
 
             .ptcd-next-departure {
-                font-size: 0.85em;
+                font-size: var(--ptcd-next-departure-font-size);
                 opacity: 0.9;
             }
 

--- a/src/cards/departure-card.js
+++ b/src/cards/departure-card.js
@@ -279,6 +279,7 @@ class PublicTransportDepartureCard extends PublicTransprtAbstractCard {
             .ptcd-first-departure-compact {
                 justify-content: space-between;
                 gap: var(--public-transport-card-inner-padding);
+                font-size: var(--ptcd-first-departure-font-size);
             }
 
             .ptcd-first-departure-compact .ptcd-time-departure,

--- a/src/cards/departure-card.js
+++ b/src/cards/departure-card.js
@@ -276,6 +276,35 @@ class PublicTransportDepartureCard extends PublicTransprtAbstractCard {
                 font-size: var(--ptcd-first-platform-font-size);
             }
 
+            .ptcd-first-departure-compact {
+                justify-content: space-between;
+                gap: var(--public-transport-card-inner-padding);
+            }
+
+            .ptcd-first-departure-compact .ptcd-time-departure,
+            .ptcd-first-departure-compact .ptcd-time-departure-offset,
+            .ptcd-first-departure-compact .ptcd-train,
+            .ptcd-first-departure-compact .ptcd-platform {
+                flex: 1;
+            }
+
+            .ptcd-first-departure-compact .ptcd-direction {
+                flex: 2;
+                white-space: nowrap;
+            }
+
+            .ptcd-first-departure-compact .ptcd-next-stations {
+                flex: 3;
+                flex-shrink: 2;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            .ptcd-first-departure-compact .ptcd-platform:last-child {
+                text-align: right;
+            }
+
             .ptcd-next-departure {
                 font-size: var(--ptcd-next-departure-font-size);
                 opacity: 0.9;
@@ -328,9 +357,16 @@ class PublicTransportDepartureCard extends PublicTransprtAbstractCard {
         const nextDepartures = [...departures];
         const firstDeparture = layoutConfig.firstDepartureLayout ? nextDepartures.shift() : undefined;
 
+        // use compact single-row layout if nextStations is empty
+        const firstDepartureCompact = firstDeparture && firstDeparture.nextStations.length === 0;
+
         return html`
             <div class="ptcd-main ptcd-layout-${this.config.layout}" @click="${(ev) => this.handleAction('tap')}">
-                ${layoutConfig.firstDepartureLayout && firstDeparture ? html`
+                ${layoutConfig.firstDepartureLayout && firstDeparture ? (firstDepartureCompact ? html`
+                    <div class="ptcd-row ptcd-first-departure ptcd-first-departure-compact ${firstDeparture.isCancelled ? 'ptcd-is-cancelled' : ''}">
+                        ${layoutConfig.columns.map(column => this._renderColumn(firstDeparture, column))}
+                    </div>
+                ` : html`
                     <div class="ptcd-row ptcd-first-departure ${firstDeparture.isCancelled ? 'ptcd-is-cancelled' : ''}">
                         ${layoutConfig.firstDepartureLayout.map(row => html`
                             <div class="ptcd-first-departure-section ${row.length === 0 ? 'ptcd-spacer' : ''}">
@@ -338,7 +374,7 @@ class PublicTransportDepartureCard extends PublicTransprtAbstractCard {
                             </div>
                         `)}
                     </div>
-                ` : ''}
+                `) : ''}
                 ${nextDepartures.map(departure => html`
                     <div class="ptcd-row ptcd-next-departure ${departure.isCancelled ? 'ptcd-is-cancelled' : ''}">
                         ${layoutConfig.columns.map(column => this._renderColumn(departure, column))}

--- a/src/cards/departure-card.js
+++ b/src/cards/departure-card.js
@@ -1,3 +1,4 @@
+
 /**
  * @typedef {CardConfig&{
  *    layout: string,

--- a/src/cards/departure-card.js
+++ b/src/cards/departure-card.js
@@ -1,4 +1,3 @@
-
 /**
  * @typedef {CardConfig&{
  *    layout: string,
@@ -206,6 +205,7 @@ class PublicTransportDepartureCard extends PublicTransprtAbstractCard {
                  * --ptcd-next-departure-font-size   Alle Folgezeilen
                  */
                 --ptcd-first-departure-font-size: 1em;
+                --ptcd-first-departure-second-font-size: 0.85em;
                 --ptcd-first-platform-font-size: 1.2em;
                 --ptcd-next-departure-font-size: 0.85em;
             }
@@ -263,6 +263,10 @@ class PublicTransportDepartureCard extends PublicTransprtAbstractCard {
 
             .ptcd-first-departure > .ptcd-first-departure-section > :first-child {
                 font-size: var(--ptcd-first-departure-font-size);
+            }
+
+            .ptcd-first-departure > .ptcd-first-departure-section > :last-child:not(:first-child) {
+                font-size: var(--ptcd-first-departure-second-font-size);
             }
 
             .ptcd-first-departure > .ptcd-first-departure-section > .ptcd-platform:first-child:last-child {


### PR DESCRIPTION
Adds CSS custom properties to allow per-card font size overrides via card_mod without modifying source files.

[Feature Request]: font sizes #32



New variables:

--ptc-title-font-size (default: 16px) — card title
--ptcd-first-departure-font-size (default: 1em) — first departure: time and train
--ptcd-first-departure-second-font-size (default: 0.85em) — first departure: second line
--ptcd-first-platform-font-size (default: 1.2em) — first departure: platform number
--ptcd-next-departure-font-size (default: 0.85em) — all subsequent departures





Behavior change:

When a departure has no intermediate stations (next_stations is empty), the first departure is rendered as a single compact row — identical in structure to the subsequent departure rows — instead of the two-line expanded layout. This avoids an empty second line and keeps the card compact.



Usage:

Install card_mod via HACS, then add the following to your card configuration:
yamlcard_mod:
  style:
    ha-card:
      $: |
        :host {
          --ptc-title-font-size: 14px;
          --ptcd-first-departure-font-size: 0.9em;
          --ptcd-first-departure-second-font-size: 0.8em;
          --ptcd-first-platform-font-size: 1em;
          --ptcd-next-departure-font-size: 0.8em;
        }
<img width="530" height="199" alt="Screenshot 2026-06-12 110838" src="https://github.com/user-attachments/assets/13dc4b26-6443-4ada-a69a-4c590730088e" />
